### PR TITLE
Adding dependency to underscore to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "keywords": [
     "react-component"
   ],
+  "dependencies": {
+    "underscore": "^1.8.3"
+  },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-eslint": "^7.1.1",


### PR DESCRIPTION
As underscore is used for several components, it should be marked as dependency.