### PR TITLE
Only call getDefaultValue when this.props.value === undefined, because

### DIFF
--- a/src/select.jsx
+++ b/src/select.jsx
@@ -51,7 +51,7 @@ export default class SelectComponent extends React.Component {
   }
 
   componentDidMount () {
-    if (!this.props.value) {
+    if (typeof this.props.value === "undefined") {
       this.props.onChange(this.getDefaultValue())
     }
   }


### PR DESCRIPTION
Material-ui offers nullable selects: http://www.material-ui.com/#/components/select-field
Also 0 and "" are valid items for select menus.